### PR TITLE
Integrate social OAuth sign-in buttons

### DIFF
--- a/src/features/auth/components/SocialMediaButton.tsx
+++ b/src/features/auth/components/SocialMediaButton.tsx
@@ -1,12 +1,14 @@
-import { Text, TouchableOpacity, View } from "react-native";
+import { ActivityIndicator, Text, TouchableOpacity, View } from "react-native";
 
 import { AntDesign, FontAwesome } from "@expo/vector-icons";
 
-export type Provider = "google" | "apple";
+export type Provider = "google" | "github" | "apple";
 
 export interface SocialMediaButtonProps {
   provider: Provider;
   onPress: () => void;
+  disabled?: boolean;
+  loading?: boolean;
 }
 
 const providerConfig = {
@@ -18,6 +20,15 @@ const providerConfig = {
     textColor: "text-gray-800",
     iconColor: "#1f2937",
     borderColor: "border border-gray-300",
+  },
+  github: {
+    icon: "github" as const,
+    iconFamily: "AntDesign" as const,
+    label: "Continue with GitHub",
+    bgColor: "bg-zinc-900",
+    textColor: "text-white",
+    iconColor: "white",
+    borderColor: "",
   },
   apple: {
     icon: "apple" as const,
@@ -33,15 +44,22 @@ const providerConfig = {
 export default function SocialMediaButton({
   provider,
   onPress,
+  disabled = false,
+  loading = false,
 }: SocialMediaButtonProps) {
   const config = providerConfig[provider];
+  const isDisabled = disabled || loading;
 
   return (
     <TouchableOpacity
-      className={`w-full flex-row items-center justify-center rounded-lg p-4 ${config.bgColor} ${config.borderColor}`}
+      className={`w-full flex-row items-center justify-center rounded-lg p-4 ${config.bgColor} ${config.borderColor} ${
+        isDisabled ? "opacity-60" : ""
+      }`}
       onPress={onPress}
+      disabled={isDisabled}
       accessibilityRole="button"
       accessibilityLabel={`${config.label} button`}
+      accessibilityState={{ disabled: isDisabled, busy: loading }}
     >
       <View className="absolute left-4">
         {config.iconFamily === "AntDesign" ? (
@@ -53,6 +71,11 @@ export default function SocialMediaButton({
       <Text className={`font-semibold ${config.textColor}`}>
         {config.label}
       </Text>
+      {loading ? (
+        <View className="absolute right-4">
+          <ActivityIndicator size="small" color={config.iconColor} />
+        </View>
+      ) : null}
     </TouchableOpacity>
   );
 }

--- a/src/features/auth/screens/SocialOauthSection.tsx
+++ b/src/features/auth/screens/SocialOauthSection.tsx
@@ -1,10 +1,56 @@
-import { View } from "react-native";
+import { useCallback, useState } from "react";
+
+import { Alert, View } from "react-native";
 
 import { Text } from "@react-navigation/elements";
+import type { AuthError } from "@supabase/supabase-js";
 
-import SocialMediaButton from "../components/SocialMediaButton";
+import { useOAuthSignIn } from "@/src/features/auth/hooks/useOAuthSignIn";
 
-export default function SocialOauthSection({ title }: { title: string }) {
+import SocialMediaButton, {
+  type Provider,
+} from "../components/SocialMediaButton";
+
+const OAUTH_PROVIDERS: Provider[] = ["google", "github", "apple"];
+
+interface SocialOauthSectionProps {
+  title: string;
+  onSuccess?: (provider: Provider) => void;
+  onError?: (error: AuthError, provider: Provider) => void;
+}
+
+export default function SocialOauthSection({
+  title,
+  onSuccess,
+  onError,
+}: SocialOauthSectionProps) {
+  const [pendingProvider, setPendingProvider] = useState<Provider | null>(null);
+  const { mutateAsync: signInWithOAuth } = useOAuthSignIn();
+
+  const handleSocialSignIn = useCallback(
+    async (provider: Provider) => {
+      try {
+        setPendingProvider(provider);
+        await signInWithOAuth(provider);
+        onSuccess?.(provider);
+      } catch (error) {
+        const authError = error as AuthError;
+        if (onError) {
+          onError(authError, provider);
+        } else {
+          Alert.alert(
+            "Social sign-in failed",
+            authError?.message ??
+              "We couldn't continue with that provider. Please try again.",
+          );
+        }
+      } finally {
+        setPendingProvider(null);
+      }
+    },
+    [onError, onSuccess, signInWithOAuth],
+  );
+
   return (
     <View className="flex w-full flex-col items-center justify-center gap-4">
       <View className="flex w-full flex-col items-center justify-center gap-2">
@@ -13,8 +59,15 @@ export default function SocialOauthSection({ title }: { title: string }) {
         </Text>
       </View>
       <View className="flex w-full flex-col items-center gap-4">
-        <SocialMediaButton provider="google" onPress={() => void 0} />
-        <SocialMediaButton provider="apple" onPress={() => void 0} />
+        {OAUTH_PROVIDERS.map((provider) => (
+          <SocialMediaButton
+            key={provider}
+            provider={provider}
+            onPress={() => void handleSocialSignIn(provider)}
+            disabled={pendingProvider !== null}
+            loading={pendingProvider === provider}
+          />
+        ))}
       </View>
     </View>
   );


### PR DESCRIPTION
## Summary
- connect the social sign-in section to the Supabase OAuth hook and surface friendly error handling
- add GitHub support plus loading/disabled states to the shared social button component

## Testing
- pnpm check

------
https://chatgpt.com/codex/tasks/task_e_68ecfd45433c8332a3b8d03a60dbbbb2